### PR TITLE
Generate ETag using a callback

### DIFF
--- a/src/EtagConditionals.php
+++ b/src/EtagConditionals.php
@@ -2,6 +2,57 @@
 
 namespace Werk365\EtagConditionals;
 
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
 class EtagConditionals
 {
+    /**
+     * The callback used to generate the ETag.
+     *
+     * @var \Closure|null
+     */
+    protected static $etagGenerateCallback;
+
+    /**
+     * Set a callback that should be used when generating the ETag.
+     *
+     * @param  \Closure|null  $callback
+     * @return void
+     */
+    public static function etagGenerateUsing(?Closure $callback): void
+    {
+        static::$etagGenerateCallback = $callback;
+    }
+
+    /**
+     * Get ETag value for this request and response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @return string
+     */
+    public static function getEtag(Request $request, Response $response): string
+    {
+        if (static::$etagGenerateCallback) {
+            $etag = call_user_func(static::$etagGenerateCallback, $request, $response);
+        } else {
+            $etag = static::defaultGetEtag($response);
+        }
+
+        return (string) Str::of($etag)->start('"')->finish('"');
+    }
+
+    /**
+     * Get default ETag value.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @return string
+     */
+    private static function defaultGetEtag(Response $response): string
+    {
+        return md5($response->getContent());
+    }
 }

--- a/src/Middleware/IfMatch.php
+++ b/src/Middleware/IfMatch.php
@@ -5,6 +5,7 @@ namespace Werk365\EtagConditionals\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Werk365\EtagConditionals\EtagConditionals;
 
 class IfMatch extends Middleware
 {
@@ -32,8 +33,7 @@ class IfMatch extends Middleware
         $getResponse = app()->handle($getRequest);
 
         // Get content from response object and get hashes from content and etag
-        $getContent = $getResponse->getContent();
-        $getEtag = '"'.md5($getContent).'"';
+        $getEtag = EtagConditionals::getEtag($request, $getResponse);
         $ifMatch = $request->header('If-Match');
 
         // Strip W/ if weak comparison algorithm can be used

--- a/src/Middleware/IfNoneMatch.php
+++ b/src/Middleware/IfNoneMatch.php
@@ -4,6 +4,7 @@ namespace Werk365\EtagConditionals\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Werk365\EtagConditionals\EtagConditionals;
 
 class IfNoneMatch extends Middleware
 {
@@ -29,7 +30,7 @@ class IfNoneMatch extends Middleware
         //Handle response
         $response = $next($request);
 
-        $etag = '"'.md5($response->getContent()).'"';
+        $etag = EtagConditionals::getEtag($request, $response);
         $noneMatch = $request->getETags();
 
         // Strip W/ if weak comparison algorithm can be used

--- a/src/Middleware/SetEtag.php
+++ b/src/Middleware/SetEtag.php
@@ -4,6 +4,7 @@ namespace Werk365\EtagConditionals\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Werk365\EtagConditionals\EtagConditionals;
 
 class SetEtag extends Middleware
 {
@@ -26,11 +27,11 @@ class SetEtag extends Middleware
             $request->setMethod('GET');
         }
 
-        //Handle response
+        // Handle response
         $response = $next($request);
 
         // Setting etag
-        $etag = md5($response->getContent());
+        $etag = EtagConditionals::getEtag($request, $response);
         $response->setEtag($etag);
 
         $request->setMethod($method);

--- a/tests/EtagConditionalsTest.php
+++ b/tests/EtagConditionalsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Werk365\EtagConditionals\Tests;
+
+use Illuminate\Http\Request;
+use Orchestra\Testbench\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Werk365\EtagConditionals\EtagConditionals;
+
+class EtagConditionalsTest extends TestCase
+{
+    private string $response = 'OK';
+
+    public function tearDown(): void
+    {
+        EtagConditionals::etagGenerateUsing(null);
+    }
+
+    /** @test */
+    public function get_default_etag()
+    {
+        $request = Request::create('/', 'GET');
+        $response = response($this->response, 200);
+
+        $this->assertEquals('"e0aa021e21dddbd6d8cecec71e9cf564"', EtagConditionals::getEtag($request, $response));
+    }
+
+    /** @test */
+    public function get_etag_with_callback_md5()
+    {
+        $request = Request::create('/', 'GET');
+        $response = response($this->response, 200);
+
+        EtagConditionals::etagGenerateUsing(function (Request $request, Response $response) {
+            return md5($response->getContent());
+        });
+
+        $this->assertEquals('"e0aa021e21dddbd6d8cecec71e9cf564"', EtagConditionals::getEtag($request, $response));
+    }
+
+    /** @test */
+    public function get_etag_with_callback_sophisticated()
+    {
+        $request = Request::create('/', 'GET');
+        $response = response($this->response, 200);
+
+        EtagConditionals::etagGenerateUsing(function (Request $request, Response $response) {
+            return 'sophisticated';
+        });
+
+        $this->assertEquals('"sophisticated"', EtagConditionals::getEtag($request, $response));
+    }
+
+    /** @test */
+    public function get_etag_with_callback_with_quotes()
+    {
+        $request = Request::create('/', 'GET');
+        $response = response($this->response, 200);
+
+        EtagConditionals::etagGenerateUsing(function (Request $request, Response $response) {
+            return '"sophisticated"';
+        });
+
+        $this->assertEquals('"sophisticated"', EtagConditionals::getEtag($request, $response));
+    }
+}


### PR DESCRIPTION
This PR aims at adding the ability to create a callback to generate the ETag.

ETag can be any string, and not necessarily computed using md5 of the content. In some cases it might be interesting to let the application calculate (and maybe caching?) the ETag.

You can for instance create a callback in you `AppServiceProvider` like:
```php
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        EtagConditionals::etagGenerateUsing(function (\Illuminate\Http\Request $request, \Symfony\Component\HttpFoundation\Response $response) {
            return Cache::rememberForever('etag.'.$request->url(), function () use ($response) {
                 return md5($response->getContent());
            });
        });
    }
}
```