### PR TITLE
Check Str::of method existence for Laravel 6.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "homepage": "https://github.com/werk365/etagconditionals",
     "keywords": ["Laravel", "EtagConditionals"],
     "require": {
-        "illuminate/support": "~7|~8"
+        "illuminate/support": "~6|~7|~8"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0|~9.0",
-        "orchestra/testbench": "~5|~6"
+        "orchestra/testbench": "~4|~5|~6"
     },
     "autoload": {
         "psr-4": {

--- a/src/EtagConditionals.php
+++ b/src/EtagConditionals.php
@@ -45,7 +45,9 @@ class EtagConditionals
         if (method_exists(Str::class, 'of')) {
             return (string) Str::of($etag)->start('"')->finish('"');
         }
+
         $etag = Str::start($etag, '"');
+
         return Str::finish($etag, '"');
     }
 

--- a/src/EtagConditionals.php
+++ b/src/EtagConditionals.php
@@ -42,7 +42,11 @@ class EtagConditionals
             $etag = static::defaultGetEtag($response);
         }
 
-        return (string) Str::of($etag)->start('"')->finish('"');
+        if (method_exists(Str::class, 'of')) {
+            return (string) Str::of($etag)->start('"')->finish('"');
+        }
+        $etag = Str::start($etag, '"');
+        return Str::finish($etag, '"');
     }
 
     /**


### PR DESCRIPTION
`Str::of` hasn't implemented for Laravel 6.x, so use old syntax in such case.