### PR TITLE
Support Laravel 13.x

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 8.1
+            version: 8.3
     nodes:
         analysis:
             project_setup:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 8.3
+            version: 8.3.28
     nodes:
         analysis:
             project_setup:

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,16 @@
         }
     ],
     "homepage": "https://github.com/werk365/etagconditionals",
-    "keywords": ["Laravel", "EtagConditionals"],
+    "keywords": [
+        "Laravel",
+        "EtagConditionals"
+    ],
     "require": {
-        "illuminate/support": "~7|~8|~9|~10|~11|~12"
+        "illuminate/support": "~7|~8|~9|~10|~11|~12|^13.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.0|~9.0",
-        "orchestra/testbench": "~5|~6|~7|~8"
+        "phpunit/phpunit": "^12.0",
+        "orchestra/testbench": "~5|~6|~7|~8|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/EtagConditionalsTest.php
+++ b/tests/EtagConditionalsTest.php
@@ -2,9 +2,9 @@
 
 namespace Werk365\EtagConditionals\Tests;
 
-use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Response;
 use Werk365\EtagConditionals\EtagConditionals;
 

--- a/tests/EtagConditionalsTest.php
+++ b/tests/EtagConditionalsTest.php
@@ -2,22 +2,23 @@
 
 namespace Werk365\EtagConditionals\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpFoundation\Response;
 use Werk365\EtagConditionals\EtagConditionals;
 
-class EtagConditionalsTest extends TestCase
+final class EtagConditionalsTest extends TestCase
 {
     private string $response = 'OK';
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         EtagConditionals::etagGenerateUsing(null);
     }
 
-    /** @test */
-    public function get_default_etag()
+    #[Test]
+    public function get_default_etag(): void
     {
         $request = Request::create('/', 'GET');
         $response = response($this->response, 200);
@@ -25,8 +26,8 @@ class EtagConditionalsTest extends TestCase
         $this->assertEquals('"e0aa021e21dddbd6d8cecec71e9cf564"', EtagConditionals::getEtag($request, $response));
     }
 
-    /** @test */
-    public function get_etag_with_callback_md5()
+    #[Test]
+    public function get_etag_with_callback_md5(): void
     {
         $request = Request::create('/', 'GET');
         $response = response($this->response, 200);
@@ -38,8 +39,8 @@ class EtagConditionalsTest extends TestCase
         $this->assertEquals('"e0aa021e21dddbd6d8cecec71e9cf564"', EtagConditionals::getEtag($request, $response));
     }
 
-    /** @test */
-    public function get_etag_with_callback_sophisticated()
+    #[Test]
+    public function get_etag_with_callback_sophisticated(): void
     {
         $request = Request::create('/', 'GET');
         $response = response($this->response, 200);
@@ -51,8 +52,8 @@ class EtagConditionalsTest extends TestCase
         $this->assertEquals('"sophisticated"', EtagConditionals::getEtag($request, $response));
     }
 
-    /** @test */
-    public function get_etag_with_callback_with_quotes()
+    #[Test]
+    public function get_etag_with_callback_with_quotes(): void
     {
         $request = Request::create('/', 'GET');
         $response = response($this->response, 200);

--- a/tests/IfMatchTest.php
+++ b/tests/IfMatchTest.php
@@ -2,9 +2,9 @@
 
 namespace Werk365\EtagConditionals\Tests;
 
-use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Support\Facades\Config;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Werk365\EtagConditionals\Middleware\IfMatch;
 
 final class IfMatchTest extends TestCase

--- a/tests/IfMatchTest.php
+++ b/tests/IfMatchTest.php
@@ -2,15 +2,16 @@
 
 namespace Werk365\EtagConditionals\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Support\Facades\Config;
 use Orchestra\Testbench\TestCase;
 use Werk365\EtagConditionals\Middleware\IfMatch;
 
-class IfMatchTest extends TestCase
+final class IfMatchTest extends TestCase
 {
     private string $response = 'OK';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -19,8 +20,8 @@ class IfMatchTest extends TestCase
         });
     }
 
-    /** @test */
-    public function patch_request_returns_200_if_matching_IfMatch()
+    #[Test]
+    public function patch_request_returns_200_if_matching_IfMatch(): void
     {
         $ifMatch = '"'.md5($this->response).'"';
         $response = $this->withHeaders([
@@ -31,8 +32,8 @@ class IfMatchTest extends TestCase
         $response->assertStatus(200);
     }
 
-    /** @test */
-    public function patch_request_returns_200_if_matching_IfMatch_in_list_of_etags()
+    #[Test]
+    public function patch_request_returns_200_if_matching_IfMatch_in_list_of_etags(): void
     {
         $ifMatch = '"'.md5('first').'", "'.md5($this->response).'","'.md5('last').'"';
         $response = $this->withHeaders([
@@ -43,8 +44,8 @@ class IfMatchTest extends TestCase
         $response->assertStatus(200);
     }
 
-    /** @test */
-    public function patch_request_returns_200_if_wildcard_is_used()
+    #[Test]
+    public function patch_request_returns_200_if_wildcard_is_used(): void
     {
         $ifMatch = '"'.md5('first').'", "*","'.md5('last').'"';
         $response = $this->withHeaders([
@@ -55,8 +56,8 @@ class IfMatchTest extends TestCase
         $response->assertStatus(200);
     }
 
-    /** @test */
-    public function patch_request_returns_412_if_none_matching_IfMatch()
+    #[Test]
+    public function patch_request_returns_412_if_none_matching_IfMatch(): void
     {
         $ifMatch = '"'.md5($this->response.'ifMatch').'"';
         $response = $this->withHeaders([
@@ -67,8 +68,8 @@ class IfMatchTest extends TestCase
         $response->assertStatus(412);
     }
 
-    /** @test */
-    public function patch_request_returns_412_if_none_matching_IfMatch_in_list_of_etags()
+    #[Test]
+    public function patch_request_returns_412_if_none_matching_IfMatch_in_list_of_etags(): void
     {
         $ifMatch = '"'.md5('first').'", "'.md5($this->response.'ifMatch').'","'.md5('last').'"';
         $response = $this->withHeaders([
@@ -79,8 +80,8 @@ class IfMatchTest extends TestCase
         $response->assertStatus(412);
     }
 
-    /** @test */
-    public function patch_request_returns_200_if_matching_weaktag_when_weak_is_enabled_in_config()
+    #[Test]
+    public function patch_request_returns_200_if_matching_weaktag_when_weak_is_enabled_in_config(): void
     {
         Config::set('etagconditionals.if_match_weak', true);
         $ifMatch = 'W/"'.md5($this->response).'"';
@@ -92,8 +93,8 @@ class IfMatchTest extends TestCase
         $response->assertStatus(200);
     }
 
-    /** @test */
-    public function patch_request_returns_412_if_matching_weaktag_when_weak_is_disabled_in_config()
+    #[Test]
+    public function patch_request_returns_412_if_matching_weaktag_when_weak_is_disabled_in_config(): void
     {
         Config::set('etagconditionals.if_match_weak', false);
         $ifMatch = 'W/"'.md5($this->response).'"';

--- a/tests/IfNoneMatchTest.php
+++ b/tests/IfNoneMatchTest.php
@@ -2,15 +2,16 @@
 
 namespace Werk365\EtagConditionals\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Support\Facades\Config;
 use Orchestra\Testbench\TestCase;
 use Werk365\EtagConditionals\Middleware\IfNoneMatch;
 
-class IfNoneMatchTest extends TestCase
+final class IfNoneMatchTest extends TestCase
 {
     private string $response = 'OK';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -19,8 +20,8 @@ class IfNoneMatchTest extends TestCase
         });
     }
 
-    /** @test */
-    public function get_request_status_200_with_none_matching_IfNoneMatch()
+    #[Test]
+    public function get_request_status_200_with_none_matching_IfNoneMatch(): void
     {
         $noneMatch = '"'.md5($this->response.'NoneMatch').'"';
         $response = $this->withHeaders([
@@ -31,8 +32,8 @@ class IfNoneMatchTest extends TestCase
         $response->assertStatus(200);
     }
 
-    /** @test */
-    public function get_request_status_304_with_matching_IfNoneMatch()
+    #[Test]
+    public function get_request_status_304_with_matching_IfNoneMatch(): void
     {
         $noneMatch = '"'.md5($this->response).'"';
         $response = $this->withHeaders([
@@ -43,8 +44,8 @@ class IfNoneMatchTest extends TestCase
         $response->assertStatus(304);
     }
 
-    /** @test */
-    public function get_request_status_200_with_matching_weaktag_if_weak_is_disabled_in_config()
+    #[Test]
+    public function get_request_status_200_with_matching_weaktag_if_weak_is_disabled_in_config(): void
     {
         Config::set('etagconditionals.if_none_match_weak', false);
         $noneMatch = 'W/"'.md5($this->response).'"';
@@ -56,8 +57,8 @@ class IfNoneMatchTest extends TestCase
         $response->assertStatus(200);
     }
 
-    /** @test */
-    public function get_request_status_304_with_matching_weaktag_if_weak_is_enabled_in_config()
+    #[Test]
+    public function get_request_status_304_with_matching_weaktag_if_weak_is_enabled_in_config(): void
     {
         Config::set('etagconditionals.if_none_match_weak', true);
         $noneMatch = 'W/"'.md5($this->response).'"';

--- a/tests/IfNoneMatchTest.php
+++ b/tests/IfNoneMatchTest.php
@@ -2,9 +2,9 @@
 
 namespace Werk365\EtagConditionals\Tests;
 
-use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Support\Facades\Config;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Werk365\EtagConditionals\Middleware\IfNoneMatch;
 
 final class IfNoneMatchTest extends TestCase

--- a/tests/SetEtagTest.php
+++ b/tests/SetEtagTest.php
@@ -2,8 +2,8 @@
 
 namespace Werk365\EtagConditionals\Tests;
 
-use PHPUnit\Framework\Attributes\Test;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Werk365\EtagConditionals\Middleware\SetEtag;
 
 final class SetEtagTest extends TestCase

--- a/tests/SetEtagTest.php
+++ b/tests/SetEtagTest.php
@@ -2,14 +2,15 @@
 
 namespace Werk365\EtagConditionals\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Orchestra\Testbench\TestCase;
 use Werk365\EtagConditionals\Middleware\SetEtag;
 
-class SetEtagTest extends TestCase
+final class SetEtagTest extends TestCase
 {
     private string $response = 'OK';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -18,15 +19,15 @@ class SetEtagTest extends TestCase
         });
     }
 
-    /** @test */
-    public function middleware_sets_etag_header()
+    #[Test]
+    public function middleware_sets_etag_header(): void
     {
         $response = $this->get('/_test/set-etag');
         $response->assertHeader('ETag', $value = null);
     }
 
-    /** @test */
-    public function etag_header_has_correct_value()
+    #[Test]
+    public function etag_header_has_correct_value(): void
     {
         $value = '"'.md5($this->response).'"';
         $response = $this->get('/_test/set-etag');


### PR DESCRIPTION
* Bump dependencies for Laravel 13

* PHPUnit 12 Shift (https://github.com/chrillep/etagconditionals/pull/2)

* Bump PHPUnit dependencies

* Set return type of base TestCase methods

From the [PHPUnit 8 release notes][1], the `TestCase` methods below now declare a `void` return type:

- `setUpBeforeClass()`
- `setUp()`
- `assertPreConditions()`
- `assertPostConditions()`
- `tearDown()`
- `tearDownAfterClass()`
- `onNotSuccessfulTest()`

[1]: https://phpunit.de/announcements/phpunit-8.html

* Adopt PHP attributes in test classes

* Add return types to test methods

* Define test classes as `final`

---------


closes #27 
---------